### PR TITLE
Fix Maven build warnings

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -13,9 +13,6 @@
         <version>1.0.0</version>
     </parent>
 
-    <prerequisites>
-        <maven>3.6.3</maven>
-    </prerequisites>
 
     <repositories>
         <!-- Repo for packetevents -->
@@ -140,7 +137,7 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.4.2</version>
                 <configuration>
-                    <finalName>BetterAnticheat-${artifactId}-${project.version}</finalName>
+                    <finalName>BetterAnticheat-${project.artifactId}-${project.version}</finalName>
                     <archive>
                         <manifest>
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -26,10 +26,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>3.4.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/paper/pom.xml
+++ b/paper/pom.xml
@@ -13,9 +13,6 @@
         <version>1.0.0</version>
     </parent>
 
-    <prerequisites>
-        <maven>3.6.3</maven>
-    </prerequisites>
 
     <repositories>
         <!-- Repo for packetevents -->
@@ -113,7 +110,7 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.4.2</version>
                 <configuration>
-                    <finalName>BetterAnticheat-${artifactId}-${project.version}</finalName>
+                    <finalName>BetterAnticheat-${project.artifactId}-${project.version}</finalName>
                     <archive>
                         <manifest>
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.0.0-M3</version>
+                <version>3.4.1</version>
                 <executions>
                     <execution>
                         <id>enforce-maven</id>

--- a/pom.xml
+++ b/pom.xml
@@ -106,4 +106,28 @@
         <lamp.version>4.0.0-rc.12</lamp.version>
         <velocity.version>3.4.0-SNAPSHOT</velocity.version>
     </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M3</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.6.3</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/spigot/pom.xml
+++ b/spigot/pom.xml
@@ -13,9 +13,6 @@
         <version>1.0.0</version>
     </parent>
 
-    <prerequisites>
-        <maven>3.6.3</maven>
-    </prerequisites>
 
     <repositories>
         <!-- Repo for packetevents -->
@@ -105,7 +102,7 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.4.2</version>
                 <configuration>
-                    <finalName>BetterAnticheat-${artifactId}-${project.version}</finalName>
+                    <finalName>BetterAnticheat-${project.artifactId}-${project.version}</finalName>
                     <archive>
                         <manifest>
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>

--- a/sponge/pom.xml
+++ b/sponge/pom.xml
@@ -13,9 +13,6 @@
         <version>1.0.0</version>
     </parent>
 
-    <prerequisites>
-        <maven>3.6.3</maven>
-    </prerequisites>
 
     <repositories>
         <!-- Repo for sponge-api -->
@@ -141,7 +138,7 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.4.2</version>
                 <configuration>
-                    <finalName>BetterAnticheat-${artifactId}-${project.version}</finalName>
+                    <finalName>BetterAnticheat-${project.artifactId}-${project.version}</finalName>
                     <archive>
                         <manifest>
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>

--- a/velocity/pom.xml
+++ b/velocity/pom.xml
@@ -13,9 +13,6 @@
         <version>1.0.0</version>
     </parent>
 
-    <prerequisites>
-        <maven>3.6.3</maven>
-    </prerequisites>
 
     <repositories>
         <!-- Repo for sparej / the type library -->
@@ -150,7 +147,7 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.4.2</version>
                 <configuration>
-                    <finalName>BetterAnticheat-${artifactId}-${project.version}</finalName>
+                    <finalName>BetterAnticheat-${project.artifactId}-${project.version}</finalName>
                     <archive>
                         <manifest>
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>


### PR DESCRIPTION
Fixes some maven build warnings:

`[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for better.anticheat:core:jar:1.0.0
[WARNING] The expression ${artifactId} is deprecated. Please use ${project.artifactId} instead.
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for better.anticheat:spigot:jar:1.0.0
[WARNING] The expression ${artifactId} is deprecated. Please use ${project.artifactId} instead.
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for better.anticheat:sponge:jar:1.0.0
[WARNING] The expression ${artifactId} is deprecated. Please use ${project.artifactId} instead.
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for better.anticheat:paper:jar:1.0.0
[WARNING] The expression ${artifactId} is deprecated. Please use ${project.artifactId} instead.
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for better.anticheat:velocity:jar:1.0.0
[WARNING] The expression ${artifactId} is deprecated. Please use ${project.artifactId} instead.
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for better.anticheat:distribution:jar:1.0.0
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ line 26, column 21
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-shade-plugin is missing. @ line 30, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
[WARNING] The project better.anticheat:core:jar:1.0.0 uses prerequisites which is only intended for maven-plugin projects but not for non maven-plugin projects. For such purposes you should use the maven-enforcer-plugin. See https://maven.apache.org/enforcer/enforcer-rules/requireMavenVersion.html
[WARNING] The project better.anticheat:spigot:jar:1.0.0 uses prerequisites which is only intended for maven-plugin projects but not for non maven-plugin projects. For such purposes you should use the maven-enforcer-plugin. See https://maven.apache.org/enforcer/enforcer-rules/requireMavenVersion.html
[WARNING] The project better.anticheat:sponge:jar:1.0.0 uses prerequisites which is only intended for maven-plugin projects but not for non maven-plugin projects. For such purposes you should use the maven-enforcer-plugin. See https://maven.apache.org/enforcer/enforcer-rules/requireMavenVersion.html
[WARNING] The project better.anticheat:paper:jar:1.0.0 uses prerequisites which is only intended for maven-plugin projects but not for non maven-plugin projects. For such purposes you should use the maven-enforcer-plugin. See https://maven.apache.org/enforcer/enforcer-rules/requireMavenVersion.html
[WARNING] The project better.anticheat:velocity:jar:1.0.0 uses prerequisites which is only intended for maven-plugin projects but not for non maven-plugin projects. For such purposes you should use the maven-enforcer-plugin. See https://maven.apache.org/enforcer/enforcer-rules/requireMavenVersion.html
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO] 
[INFO] parent                                                             [pom]
[INFO] models                                                             [jar]
[INFO] cookies                                                            [jar]
[INFO] core                                                               [jar]
[INFO] spigot                                                             [jar]
[INFO] sponge                                                             [jar]
[INFO] paper                                                              [jar]
[INFO] velocity                                                           [jar]
[INFO] distribution                                                       [jar]
[INFO] 
[INFO] ----------------------< better.anticheat:parent >-----------------------
[INFO] Building parent 1.0.0                                              [1/9]
[INFO]   from pom.xml
[INFO] --------------------------------[ pom ]---------------------------------`

Becomes

```❯ mvnd clean package
[INFO] Processing build on daemon 5e439832                                                                                                                                                                                                                                                                          
[INFO] Scanning for projects...                                                                                                                                                                                                                                                                                     
[INFO] BuildTimeEventSpy is registered.                                                                                                                                                                                                                                                                             
[INFO] --------------------------------------------------------------------------------------------------------------------------                                                                                                                                                                                   
[INFO] Reactor Build Order:
[INFO] 
[INFO] parent                                                                                                               [pom]
[INFO] models                                                                                                               [jar]
[INFO] cookies                                                                                                              [jar]
[INFO] core                                                                                                                 [jar]
[INFO] spigot                                                                                                               [jar]
[INFO] sponge                                                                                                               [jar]
[INFO] paper                                                                                                                [jar]
[INFO] velocity                                                                                                             [jar]
[INFO] distribution                                                                                                         [jar]
[INFO] 
[INFO] Using the SmartBuilder implementation with a thread count of 31
[INFO] 
[INFO] -----------------------------------------------< better.anticheat:parent >------------------------------------------------
[INFO] Building parent 1.0.0                                                                                                [1/9]
[INFO]   from pom.xml
[INFO] ---------------------------------------------------------[ pom ]----------------------------------------------------------
```

